### PR TITLE
4056 audit output in rspec stdout and fix warnings reporting_client gem

### DIFF
--- a/lib/reporting_client/heap.rb
+++ b/lib/reporting_client/heap.rb
@@ -11,8 +11,8 @@ module ReportingClient
 
     HEAP_EVENT_TRACKING_URL = 'https://heapanalytics.com/api/track'
 
-    def self.call(*args)
-      new(*args).call
+    def self.call(**args)
+      new(**args).call
     end
 
     def initialize(event_name:, identity:, properties:)

--- a/spec/reporting_client/event_spec.rb
+++ b/spec/reporting_client/event_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe ReportingClient::Event do
     end
 
     context 'when no attributes defined on Current' do
-      before { event.instrument(data) }
+      before { event.instrument(success: true) }
 
       it 'sends events to heap, new relic, and land' do
         expect(ActiveSupport::Notifications).to have_received(:instrument).with(instrumentable_name, a_hash_including(success: true))
@@ -40,7 +40,7 @@ RSpec.describe ReportingClient::Event do
       before do
         ReportingClient::Current.attribute :id
         ReportingClient::Current.id = id
-        event.instrument(data)
+        event.instrument(success: true)
       end
 
       it 'sends events to heap, land, and new relic' do

--- a/spec/reporting_client/events_spec.rb
+++ b/spec/reporting_client/events_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe ReportingClient::Events do
     end
 
     context 'when no attributes defined on Current' do
-      before { event.instrument(data) }
+      before { event.instrument(success: true) }
 
       it 'sends events to heap, new relic, and land' do
         expect(ActiveSupport::Notifications).to have_received(:instrument).with('Test', a_hash_including(success: true))
@@ -58,7 +58,7 @@ RSpec.describe ReportingClient::Events do
       before do
         ReportingClient::Current.attribute :id
         ReportingClient::Current.id = id
-        event.instrument(data)
+        event.instrument(success: true)
       end
 
       it 'sends events to heap, land, and new relic' do

--- a/spec/reporting_client/heap_spec.rb
+++ b/spec/reporting_client/heap_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe ReportingClient::Heap do
           'Accept' => '*/*',
           'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
           'Content-Type' => 'application/json',
-          'User-Agent' => 'Faraday v1.10.0'
+          'User-Agent' => 'Faraday v1.10.2'
         }
       ).to_return(status: 200, body: '', headers: {})
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,6 +25,10 @@ RSpec.configure do |config|
   config.expect_with :rspec do |c|
     c.syntax = :expect
   end
+    
+  config.mock_with :rspec do |mocks|
+    mocks.allow_message_expectations_on_nil = true
+  end
 
   WebMock.disable_net_connect!
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,7 +25,7 @@ RSpec.configure do |config|
   config.expect_with :rspec do |c|
     c.syntax = :expect
   end
-    
+
   config.mock_with :rspec do |mocks|
     mocks.allow_message_expectations_on_nil = true
   end


### PR DESCRIPTION
🧪 How to Test
- Run `bundle exec rspec` and see no warnings
🧐 Post-Release Checks
- Update this gem in our other apps (I know for a fact there are a couple warnings in ADR from this gem) and run `bin/rspec` and see _less_ warnings, this gem only had a couple warnings it was causing so don't expect ALL the warnings to go away
🗒 Additional Comments
- in a `stub_request` in `spec/reporting_client/heap_spec.rb` we are expecting an exact version number of Faraday in the headers, since our Faraday version is not locked, this can cause a failing spec. Would love some feedback on how to fix this issue!