### PR TITLE
Fix outdated mock call

### DIFF
--- a/spec/reporting_client/heap_spec.rb
+++ b/spec/reporting_client/heap_spec.rb
@@ -28,8 +28,7 @@ RSpec.describe ReportingClient::Heap do
         headers: {
           'Accept' => '*/*',
           'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-          'Content-Type' => 'application/json',
-          'User-Agent' => 'Faraday v1.10.2'
+          'Content-Type' => 'application/json'
         }
       ).to_return(status: 200, body: '', headers: {})
   end


### PR DESCRIPTION
When I pulled down the repo, running `bundle exec rspec` failed due to Webmock complaining about the suite trying to send out a real HTTP request. I looked into what was going on, and I found that it was due to a mock matching the header on information about the Faraday cilent being used. I've removed it in this PR since that seems to be an unecessarily brittle thing to match on since it would break every time we update the Faraday gem.