### PR TITLE
Pin Rubocop version to prevent CI failure from version mismatch

### DIFF
--- a/reporting_client.gemspec
+++ b/reporting_client.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'rspec_junit_formatter'
-  spec.add_development_dependency 'rubocop'
+  spec.add_development_dependency 'rubocop', '1.42.0'
   spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'webmock'
 


### PR DESCRIPTION
We are having CI failures due to mismatch versions of gemes. Pinned version in the gemspec to align with gem specification style of other company gems.