### PR TITLE
222/Allow ReportingClient to Prefix Some Events With the Configured App Name

### DIFF
--- a/lib/reporting_client/configuration.rb
+++ b/lib/reporting_client/configuration.rb
@@ -3,7 +3,7 @@
 module ReportingClient
   class Configuration
     attr_accessor :environment, :heap_app_id, :instrumentable_name, :timeout, :request_logger,
-                  :prefix_event_names
+                  :prefix_new_relic_names
 
     def initialize
       @environment = nil
@@ -11,7 +11,7 @@ module ReportingClient
       @instrumentable_name = nil
       @request_logger = 'NoopLogger'
       @timeout = nil
-      @prefix_event_names = false
+      @prefix_new_relic_names = false
     end
   end
 end

--- a/lib/reporting_client/configuration.rb
+++ b/lib/reporting_client/configuration.rb
@@ -2,7 +2,8 @@
 
 module ReportingClient
   class Configuration
-    attr_accessor :environment, :heap_app_id, :instrumentable_name, :timeout, :request_logger
+    attr_accessor :environment, :heap_app_id, :instrumentable_name, :timeout, :request_logger,
+                  :prefix_event_names
 
     def initialize
       @environment = nil
@@ -10,6 +11,7 @@ module ReportingClient
       @instrumentable_name = nil
       @request_logger = 'NoopLogger'
       @timeout = nil
+      @prefix_event_names = false
     end
   end
 end

--- a/lib/reporting_client/events.rb
+++ b/lib/reporting_client/events.rb
@@ -27,8 +27,15 @@ module ReportingClient
         ActiveSupport::Notifications.subscribe(event_name) do |name, _start, _finish, _id, payload|
           payload.merge!(Current.attributes.compact) if defined?(Current) && Current.attributes.present?
 
+          name.to_s.prepend(config.instrumentable_name, '_') if config.prefix_new_relic_names
           ::NewRelic::Agent.record_custom_event(name.to_s, payload)
         end
+      end
+
+      private
+
+      def config
+        @config ||= ReportingClient.configuration
       end
     end
 

--- a/spec/reporting_client/configuration_spec.rb
+++ b/spec/reporting_client/configuration_spec.rb
@@ -38,19 +38,19 @@ RSpec.describe ReportingClient::Configuration do
       expect(subject.request_logger).to eq(configuration_params[:request_logger])
     end
 
-    it 'defaults prefix_event_names to false' do
-      expect(subject.prefix_event_names).to be false
+    it 'defaults prefix_new_relic_names to false' do
+      expect(subject.prefix_new_relic_names).to be false
     end
 
-    context 'a value is passed for prefix_event_names' do
+    context 'a value is passed for prefix_new_relic_names' do
       before do
         ReportingClient.configure do |config|
-          config.prefix_event_names = true
+          config.prefix_new_relic_names = true
         end
       end
 
       it 'includes raises_on_unsupported_event' do
-        expect(subject.prefix_event_names).to be true
+        expect(subject.prefix_new_relic_names).to be true
       end
     end
   end

--- a/spec/reporting_client/configuration_spec.rb
+++ b/spec/reporting_client/configuration_spec.rb
@@ -49,6 +49,12 @@ RSpec.describe ReportingClient::Configuration do
         end
       end
 
+      after do
+        ReportingClient.configure do |config|
+          config.prefix_new_relic_names = false
+        end
+      end
+
       it 'includes raises_on_unsupported_event' do
         expect(subject.prefix_new_relic_names).to be true
       end

--- a/spec/reporting_client/configuration_spec.rb
+++ b/spec/reporting_client/configuration_spec.rb
@@ -37,5 +37,21 @@ RSpec.describe ReportingClient::Configuration do
     it 'includes request logger' do
       expect(subject.request_logger).to eq(configuration_params[:request_logger])
     end
+
+    it 'defaults prefix_event_names to false' do
+      expect(subject.prefix_event_names).to be false
+    end
+
+    context 'a value is passed for prefix_event_names' do
+      before do
+        ReportingClient.configure do |config|
+          config.prefix_event_names = true
+        end
+      end
+
+      it 'includes raises_on_unsupported_event' do
+        expect(subject.prefix_event_names).to be true
+      end
+    end
   end
 end

--- a/spec/reporting_client/events_spec.rb
+++ b/spec/reporting_client/events_spec.rb
@@ -58,6 +58,7 @@ RSpec.describe ReportingClient::Events do
       before do
         ReportingClient::Current.attribute :id
         ReportingClient::Current.id = id
+
         event.instrument(success: true)
       end
 
@@ -94,6 +95,11 @@ RSpec.describe ReportingClient::Events do
         ReportingClient.configuration.instrumentable_name = 'Prefix'
 
         event.instrument(success: true)
+      end
+
+      after do
+        ReportingClient.configuration.prefix_new_relic_names = false
+        ReportingClient.configuration.instrumentable_name = nil
       end
 
       it 'sends prefixes the New Relic event name' do

--- a/spec/reporting_client/events_spec.rb
+++ b/spec/reporting_client/events_spec.rb
@@ -87,5 +87,18 @@ RSpec.describe ReportingClient::Events do
         end
       end
     end
+
+    context 'when configured to prefix new relic names' do
+      before do
+        ReportingClient.configuration.prefix_new_relic_names = true
+        ReportingClient.configuration.instrumentable_name = 'Prefix'
+
+        event.instrument(success: true)
+      end
+
+      it 'sends prefixes the New Relic event name' do
+        expect(NewRelic::Agent).to have_received(:record_custom_event).with('Prefix_Test', a_hash_including(success: true))
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR adds what is intended to be a backwards compatible configuration option for adding prefixes to New Relic events. This is important to allowing the Glue applicaiton to achieve compatability with multiple event logging and this gem.

The prefix configuration should default to false, and registered and instruented event names are not prefixed. The only thing that should be prefixed when the configuration is enabled is the name sent to New Relic.