### PR TITLE
Create a convenience method for instrumenting on error

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -7,7 +7,6 @@ Add the following line to your Gemfile:
 
 ```ruby
 gem 'reporting_client'
-
 ```
 
 And then execute:
@@ -61,10 +60,29 @@ Within the initializer, the following code is needed:
 ```ruby
   ActiveSupport::Notifications.subscribe(ReportingClient.configuration.instrumentable_name) do |name, _start, _finish, _id, payload|
      payload.merge!(Current.attributes.compact) if defined?(Current) && Current.attributes.present?
-  
+
     ::NewRelic::Agent.record_custom_event(name.to_s, payload)
   end
 ```
+
+# DSL Methods
+`reporting_client` comes with a DSL mix-in that can be included in classes to add methods that help reduce boilerplate and increase abstraction around common operations. In order to include this mixin in your class, add teh following line to it.
+```ruby
+include ReportingClient::DSL
+```
+By including the DSL module, you gain access to the following methods:
+
+**`report_uncaught_errors(event:, meta:)`:**
+
+`report_uncaught_errors` removes the need for common boilerplate around error decoration. A common requirement as part of setting up New Relic custom event dashboards is to dispatch failure events whenever an operation fails due to an error occuring. This results in ugly boilerplate that introduces unecessary risk for a non-business logic operation. This method removes the need for that boilerplate.
+
+For any section in which you'd like to dispatch a custom event indicating failure if an error occurs, use the following code block:
+```ruby
+report_uncaught_errors(event: event, meta: meta) do
+  # The code that you'd like to dispatch events on error for.
+end
+```
+`event`, in this circumstance is an instance of `Event` or `Events` which you'd like to use to call `instrument` on. `meta` can take one of two forms. First, it could be a `Symbol` that is the name of a method that you'd like to call in your object. That method should produce a `Hash` or some object that is compatible with being an argument for `merge` called on a `Hash`. Alternatively, `meta` could simply be an object compatible with being an argument for `merge` called on a `Hash`.
 
 ## Attribute Tracking
 For per-request tracking of dimensions, set the attribute hash for the `ReportingClient::Current` object in the `app/controllers/concerns/reporting_client/set_current.rb` concern created by the installer. Each key in the hash must be included in the initializer for the gem as described above. For any key populated, value will be pushed to reporting endpoints automatically when making use of the `ReportingClient::Events` module.
@@ -76,6 +94,3 @@ Tracking web custom events server side.
 ReportingClient::Heap.call(identity: heap_identity, event_name: event_name, properties: data)
 
 ```
-
-
-

--- a/lib/reporting_client.rb
+++ b/lib/reporting_client.rb
@@ -6,6 +6,7 @@ require 'reporting_client/exceptions'
 require 'reporting_client/event'
 require 'reporting_client/events'
 require 'reporting_client/heap'
+require 'reporting_client/dsl'
 require 'reporting_client/version'
 
 module ReportingClient

--- a/lib/reporting_client/dsl.rb
+++ b/lib/reporting_client/dsl.rb
@@ -5,11 +5,11 @@ module ReportingClient
     private
 
     def report_uncaught_errors(event:, meta:)
-      meta = send(meta) if meta.is_a? Symbol
-
       yield
     rescue StandardError => e
+      meta = send(meta) if meta.is_a? Symbol
       event.instrument(success: false, fail_reason: e.message, meta: meta)
+
       raise e
     end
   end

--- a/lib/reporting_client/dsl.rb
+++ b/lib/reporting_client/dsl.rb
@@ -10,6 +10,7 @@ module ReportingClient
       yield
     rescue StandardError => e
       event.instrument(success: false, fail_reason: e.message, meta: meta)
+      raise e
     end
   end
 end

--- a/lib/reporting_client/dsl.rb
+++ b/lib/reporting_client/dsl.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module ReportingClient
+  module DSL
+    private
+
+    def report_uncaught_errors(event:, meta:)
+      meta = send(meta) if meta.is_a? Symbol
+
+      yield
+    rescue StandardError => e
+      event.instrument(success: false, fail_reason: e.message, meta: meta)
+    end
+  end
+end

--- a/spec/reporting_client/dsl_spec.rb
+++ b/spec/reporting_client/dsl_spec.rb
@@ -76,8 +76,8 @@ RSpec.describe ReportingClient::DSL do
   describe '#report_uncaught_errors' do
     context 'when no error is raised' do
       context 'when no block is given' do
-        it 'returns nil' do
-          expect(Foo.new.error_method).to be_nil
+        it 'raieses LocalJumpError' do
+          expect { Foo.new.error_method }.to raise_error(LocalJumpError)
         end
       end
 
@@ -101,7 +101,7 @@ RSpec.describe ReportingClient::DSL do
 
       context 'when the meta is a variable' do
         it 'instruments with the meta' do
-          Foo.new.method_b
+          expect { Foo.new.method_b }.to raise_error(StandardError)
 
           expect(event).to have_received(:instrument).with(instrument_hash)
         end
@@ -109,7 +109,7 @@ RSpec.describe ReportingClient::DSL do
 
       context 'when the meta is a symbol' do
         it 'instruments the meta by sending the symbol' do
-          Foo.new.method_c
+          expect { Foo.new.method_c }.to raise_error(StandardError)
 
           expect(event).to have_received(:instrument).with(instrument_hash)
         end
@@ -122,7 +122,7 @@ RSpec.describe ReportingClient::DSL do
           let(:meta) { { bat: :value_a } }
 
           it "doesn't update the value" do
-            Foo.new.method_d
+            expect { Foo.new.method_d }.to raise_error(StandardError)
 
             expect(event).to have_received(:instrument).with(instrument_hash)
           end
@@ -132,7 +132,7 @@ RSpec.describe ReportingClient::DSL do
           let(:meta) { { bat: :value_b } }
 
           it 'does update the value' do
-            Foo.new.method_e
+            expect { Foo.new.method_e }.to raise_error(StandardError)
 
             expect(event).to have_received(:instrument).with(instrument_hash)
           end
@@ -142,7 +142,7 @@ RSpec.describe ReportingClient::DSL do
           let(:meta) { { bat: :value_a } }
 
           it 'does update the value' do
-            Foo.new.method_f
+            expect { Foo.new.method_f }.to raise_error(StandardError)
 
             expect(event).to have_received(:instrument).with(instrument_hash)
           end

--- a/spec/reporting_client/dsl_spec.rb
+++ b/spec/reporting_client/dsl_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe ReportingClient::DSL do
         end
 
         context 'when the meta is a symbol' do
-          let(:meta) { { bat: :value_a } }
+          let(:meta) { { bat: :value_b } }
 
           it 'does update the value' do
             expect { Foo.new.method_f }.to raise_error(StandardError)

--- a/spec/reporting_client/dsl_spec.rb
+++ b/spec/reporting_client/dsl_spec.rb
@@ -1,0 +1,153 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+class Foo
+  include ReportingClient::DSL
+
+  attr_accessor :bat
+
+  def initialize
+    @bat = :value_a
+  end
+
+  def error_method
+    report_uncaught_errors(event: event, meta: meta)
+  end
+
+  def method_a
+    report_uncaught_errors(event: event, meta: meta) do
+      return :success
+    end
+  end
+
+  def method_b
+    meta = { bat: @bat }
+
+    report_uncaught_errors(event: event, meta: meta) do
+      raise StandardError, 'Oops'
+    end
+  end
+
+  def method_c
+    report_uncaught_errors(event: event, meta: :meta) do
+      raise StandardError, 'Oops'
+    end
+  end
+
+  def method_d
+    report_uncaught_errors(event: event, meta: { bat: @bat }) do
+      @bat = :value_b
+      raise StandardError, 'Delayed oops'
+    end
+  end
+
+  def method_e
+    meta = { bat: @bat }
+
+    report_uncaught_errors(event: event, meta: meta) do
+      meta[:bat] = :value_b
+      raise StandardError, 'Delayed oops'
+    end
+  end
+
+  def method_f
+    report_uncaught_errors(event: event, meta: :meta) do
+      @bat = :value_b
+      raise StandardError, 'Delayed oops'
+    end
+  end
+
+  private
+
+  def meta
+    { bat: @bat }
+  end
+
+  def event
+    @event ||= ReportingClient::Event.new
+  end
+end
+
+RSpec.describe ReportingClient::DSL do
+  # Usually testing private methods is bad, but since this private method is being
+  # exported to other applications for use internally in classes for reporting,
+  # it's probably best to have a regression test for it in the gem.
+  describe '#report_uncaught_errors' do
+    context 'when no error is raised' do
+      context 'when no block is given' do
+        it 'returns nil' do
+          expect(Foo.new.error_method).to be_nil
+        end
+      end
+
+      context 'when a block is given' do
+        it 'returns the block value' do
+          expect(Foo.new.method_a).to eq :success
+        end
+      end
+    end
+
+    context 'when an error is raised' do
+      let(:event) { instance_double(ReportingClient::Event) }
+      let(:instrument_hash) { { success: false, fail_reason: fail_reason, meta: meta } }
+      let(:fail_reason) { 'Oops' }
+      let(:meta) { { bat: :value_a } }
+
+      before do
+        allow(ReportingClient::Event).to receive(:new).and_return(event)
+        allow(event).to receive(:instrument).and_return(true)
+      end
+
+      context 'when the meta is a variable' do
+        it 'instruments with the meta' do
+          Foo.new.method_b
+
+          expect(event).to have_received(:instrument).with(instrument_hash)
+        end
+      end
+
+      context 'when the meta is a symbol' do
+        it 'instruments the meta by sending the symbol' do
+          Foo.new.method_c
+
+          expect(event).to have_received(:instrument).with(instrument_hash)
+        end
+      end
+
+      context 'when the meta value has be modified in the block' do
+        let(:fail_reason) { 'Delayed oops' }
+
+        context 'when the meta is instantiated in the method signature' do
+          let(:meta) { { bat: :value_a } }
+
+          it "doesn't update the value" do
+            Foo.new.method_d
+
+            expect(event).to have_received(:instrument).with(instrument_hash)
+          end
+        end
+
+        context 'when the meta is a variable' do
+          let(:meta) { { bat: :value_b } }
+
+          it 'does update the value' do
+            Foo.new.method_e
+
+            expect(event).to have_received(:instrument).with(instrument_hash)
+          end
+        end
+
+        context 'when the meta is a symbol' do
+          let(:meta) { { bat: :value_a } }
+
+          it 'does update the value' do
+            Foo.new.method_f
+
+            expect(event).to have_received(:instrument).with(instrument_hash)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
One frequent problem that we run into on Glue is that we'd like to create custom events when a flow errors out. This has led to tons and tons of dangerous boilerplate where we attempt to decorate error raises so that we can get this information in New Relic. Error decoration is probably the only way to fix this, but my hope is that we can eliminate the need for the boilerplate and the need to constantly repeat the risk of forgetting to re-raise `StandardError`. This PR implements a DSL module that can be included to classes. That DSL module includes a private method to `report_uncaught_errors`.

## Testing Instructions
* Run `bundle console` in your terminal with the `reporting_client` repo open.
* Run `ReportingClient.configuration.instrumentable_name = "Test"`
* Run the following:
```ruby
ActiveSupport::Notifications.subscribe("Test") do |name, start, finish, id, payload|
  puts payload
end
```
* Paste the following code into your terminal to set up a class for testing stuff
```ruby
class Foo
  include ReportingClient::DSL

  attr_accessor :bat

  def initialize
    @bat = :value_a
  end

  def error_method
    report_uncaught_errors(event: event, meta: meta)
  end

  def method_a
    report_uncaught_errors(event: event, meta: meta) do
      return :success
    end
  end

  def method_b
    meta = { bat: @bat }

    report_uncaught_errors(event: event, meta: meta) do
      raise StandardError, 'Oops'
    end
  end

  def method_c
    report_uncaught_errors(event: event, meta: :meta) do
      raise StandardError, 'Oops'
    end
  end

  def method_d
    report_uncaught_errors(event: event, meta: { bat: @bat }) do
      @bat = :value_b
      raise StandardError, 'Delayed oops'
    end
  end

  def method_e
    meta = { bat: @bat }

    report_uncaught_errors(event: event, meta: meta) do
      meta[:bat] = :value_b
      raise StandardError, 'Delayed oops'
    end
  end

  def method_f
    report_uncaught_errors(event: event, meta: :meta) do
      @bat = :value_b
      raise StandardError, 'Delayed oops'
    end
  end

  private

  def meta
    { bat: @bat }
  end

  def event
    @event ||= ReportingClient::Event.new
  end
end
```
* Now you can test for the anticipated results
* Instantiate an instance of `Foo` and check that each method produces the following results
  * `#method_a` returns :success
  * `#method_b` prints out a hash with `bat: :value_a` and then raises an error
  * `#method_c` prints out a hash with `bat: :value_a` and then raises an error
  * `#method_d` prints out a hash with `bat: :value_a` and then raises an error
  * `#method_e` prints out a hash with `bat: :value_b` and then raises an error
  * `#method_f` prints out a hash with `bat: :value_b` and then raises an error