### PR TITLE
Bug/Fix frozen string modification in place risk

### DIFF
--- a/lib/reporting_client/events.rb
+++ b/lib/reporting_client/events.rb
@@ -27,7 +27,7 @@ module ReportingClient
         ActiveSupport::Notifications.subscribe(event_name) do |name, _start, _finish, _id, payload|
           payload.merge!(Current.attributes.compact) if defined?(Current) && Current.attributes.present?
 
-          name = "#{config.instrumentable_name}_" + name.to_s if config.prefix_new_relic_names
+          name = "#{config.instrumentable_name}_#{name.to_s}" if config.prefix_new_relic_names
           ::NewRelic::Agent.record_custom_event(name.to_s, payload)
         end
       end

--- a/lib/reporting_client/events.rb
+++ b/lib/reporting_client/events.rb
@@ -27,7 +27,7 @@ module ReportingClient
         ActiveSupport::Notifications.subscribe(event_name) do |name, _start, _finish, _id, payload|
           payload.merge!(Current.attributes.compact) if defined?(Current) && Current.attributes.present?
 
-          name = "#{config.instrumentable_name}_#{name.to_s}" if config.prefix_new_relic_names
+          name = "#{config.instrumentable_name}_#{name}" if config.prefix_new_relic_names
           ::NewRelic::Agent.record_custom_event(name.to_s, payload)
         end
       end

--- a/lib/reporting_client/events.rb
+++ b/lib/reporting_client/events.rb
@@ -27,7 +27,7 @@ module ReportingClient
         ActiveSupport::Notifications.subscribe(event_name) do |name, _start, _finish, _id, payload|
           payload.merge!(Current.attributes.compact) if defined?(Current) && Current.attributes.present?
 
-          name.to_s.prepend(config.instrumentable_name, '_') if config.prefix_new_relic_names
+          name = "#{config.instrumentable_name}_" + name.to_s if config.prefix_new_relic_names
           ::NewRelic::Agent.record_custom_event(name.to_s, payload)
         end
       end


### PR DESCRIPTION
Fixes a bug where `prepend` would attempt to modify frozen strings in place before failing. This is a latent bug that might be triggered depending on how custom event names are defined.

## Testing Instructions
* Run `bundle console` to open a session with `reporting_client` open
* Set the prefix for the reporting client by running the following code
```ruby
ReportingClient.configure do |config|
  config.instrumentable_name = 'Glue'
  config.prefix_new_relic_names = true
end
```
* Require the methods necessary to run the gem
```ruby
require 'active_support/core_ext/string/inflections'
```
* Attempt to register the name and ensure it doesn't fail due to frozen string issues using the following code
```ruby
ReportingClient::Events.register('TestEvent'.freeze)
```
* Create an instance of the event and attempt to instrument it. Ensure that it doesn't raise a `FrozenError`.
```ruby
event = ReportingClient::Events.new(event_name: 'TestEvent'.freeze)
event.instrument(success: true)
```