### PR TITLE
give option to put heap in the background

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 .rspec_status
 ./Gemfile.lock
 Gemfile.lock
+/.idea/

--- a/lib/reporting_client.rb
+++ b/lib/reporting_client.rb
@@ -8,6 +8,7 @@ require 'reporting_client/events'
 require 'reporting_client/heap'
 require 'reporting_client/dsl'
 require 'reporting_client/version'
+require 'reporting_client/heap_job'
 
 module ReportingClient
   class << self

--- a/lib/reporting_client/configuration.rb
+++ b/lib/reporting_client/configuration.rb
@@ -3,7 +3,7 @@
 module ReportingClient
   class Configuration
     attr_accessor :environment, :heap_app_id, :instrumentable_name, :timeout, :request_logger,
-                  :prefix_new_relic_names, :raises_on_unsupported_event, :heap_async, :heap_async_proc
+                  :prefix_new_relic_names, :raises_on_unsupported_event, :heap_async
 
     def initialize
       @environment = nil

--- a/lib/reporting_client/configuration.rb
+++ b/lib/reporting_client/configuration.rb
@@ -3,7 +3,7 @@
 module ReportingClient
   class Configuration
     attr_accessor :environment, :heap_app_id, :instrumentable_name, :timeout, :request_logger,
-                  :prefix_new_relic_names, :raises_on_unsupported_event
+                  :prefix_new_relic_names, :raises_on_unsupported_event, :heap_async, :heap_async_proc
 
     def initialize
       @environment = nil
@@ -13,6 +13,7 @@ module ReportingClient
       @timeout = nil
       @prefix_new_relic_names = false
       @raises_on_unsupported_event = false
+      @heap_async = false
     end
   end
 end

--- a/lib/reporting_client/heap.rb
+++ b/lib/reporting_client/heap.rb
@@ -3,6 +3,7 @@
 require 'faraday'
 require 'json'
 require_relative 'noop_logger'
+require_relative './heap_job'
 
 module ReportingClient
   class Heap
@@ -21,6 +22,14 @@ module ReportingClient
     end
 
     def call
+      if config.heap_async
+        HeapJob.perform_later(event_name, identity, properties)
+      else
+        track
+      end
+    end
+
+    def track
       response = conn.post do |req|
         req.body = body
         req.options[:timeout] = config.timeout

--- a/lib/reporting_client/heap_job.rb
+++ b/lib/reporting_client/heap_job.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'active_job'
+require_relative './heap'
+
+module ReportingClient
+  class HeapJob < ActiveJob::Base
+    def perform(event_name, identity, properties)
+      Heap.new(event_name: event_name, identity: identity, properties: properties).track
+    end
+  end
+end

--- a/reporting_client.gemspec
+++ b/reporting_client.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'webmock'
 
+  spec.add_runtime_dependency 'activejob'
   spec.add_runtime_dependency 'faraday', '>= 2.0'
   spec.add_runtime_dependency 'request_store'
   spec.metadata['rubygems_mfa_required'] = 'true'

--- a/spec/reporting_client/heap_job_spec.rb
+++ b/spec/reporting_client/heap_job_spec.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+RSpec.describe ReportingClient::HeapJob do
+  it 'calls Heap#track' do
+    expect_any_instance_of(ReportingClient::Heap).to receive(:track)
+    described_class.perform_now('event_name', 'identity', 'properties')
+  end
+end

--- a/spec/reporting_client/heap_spec.rb
+++ b/spec/reporting_client/heap_spec.rb
@@ -47,4 +47,24 @@ RSpec.describe ReportingClient::Heap do
       expect { subject }.to raise_error(StandardError)
     end
   end
+
+  context 'with heap async set to true' do
+    it 'enqueues a heap job' do
+      allow(config).to receive(:heap_async).and_return(true)
+
+      expect(ReportingClient::HeapJob).to receive(:perform_later).with(event_name, program_name, properties)
+      expect(Faraday).not_to receive(:new)
+      subject
+    end
+  end
+
+  context 'with heap async set to false' do
+    it 'does not enqueue a heap job' do
+      allow(config).to receive(:heap_async).and_return(false)
+
+      expect(ReportingClient::HeapJob).not_to receive(:perform_later)
+      expect(Faraday).to receive(:new).and_return(double(post: true))
+      subject
+    end
+  end
 end


### PR DESCRIPTION
Users of this gem might not want to have the heap analytics run in the foreground as it is a blocking web request and if this gem is used in the context of web requests, this can cause slowdowns if the response from heap takes too long. This change will give users the option to run heap in the background using active job