### PR TITLE
add exception serializer

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
       - run:
           name: Bundle Install
           command: |
-            gem install bundler
+            gem install bundler -v 2.4.22
             bundle check || bundle install
       - run:
           name: Install Code Climate Test Reporter
@@ -92,7 +92,7 @@ jobs:
       - run:
           name: Bundle Install
           command: |
-            gem install bundler
+            gem install bundler -v 2.4.22
             bundle check || bundle install
       - run:
           name: rubocop

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ jobs:
       - run:
           name: Bundle Install
           command: |
-            gem install bundler
+            gem install bundler -v 2.4.22
             bundle check || bundle install
       - save_cache:
           key: reporting_client-{{ checksum "reporting_client.gemspec" }}

--- a/lib/reporting_client.rb
+++ b/lib/reporting_client.rb
@@ -9,6 +9,7 @@ require 'reporting_client/heap'
 require 'reporting_client/dsl'
 require 'reporting_client/version'
 require 'reporting_client/heap_job'
+require 'reporting_client/exception_serializer'
 
 module ReportingClient
   class << self

--- a/lib/reporting_client/exception_serializer.rb
+++ b/lib/reporting_client/exception_serializer.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require "json/add/exception"
 
 module ReportingClient
   class ExceptionSerializer < ActiveJob::Serializers::ObjectSerializer
@@ -7,27 +8,11 @@ module ReportingClient
     end
 
     def serialize(exception)
-      {
-        'class' => exception.class.name,
-        'message' => exception.message,
-        'detailed_message' => exception.respond_to?(:detailed_message) ? exception.detailed_message : nil,
-        'full_message' => exception.respond_to?(:full_message) ? exception.full_message : nil,
-        'backtrace_locations' => exception.respond_to?(:backtrace_locations) ? exception.backtrace_locations : nil,
-        'backtrace' => exception.backtrace,
-        'cause' => exception.cause,
-        'exception' => exception.respond_to?(:exception) ? exception.exception : nil
-      }.compact_blank
+      exception.as_json
     end
 
     def deserialize(hash)
-      error = hash['class'].constantize.new(hash['message'])
-      error.instance_variable_set(:@detailed_message, hash['detailed_message'])
-      error.instance_variable_set(:@full_message, hash['full_message'])
-      error.instance_variable_set(:@backtrace_locations, hash['backtrace_locations'])
-      error.instance_variable_set(:@backtrace, hash['backtrace'])
-      error.instance_variable_set(:@cause, hash['cause'])
-      error.instance_variable_set(:@exception, hash['exception'])
-      error
+      hash['json_class'].constantize.json_create(hash)
     end
   end
 end

--- a/lib/reporting_client/exception_serializer.rb
+++ b/lib/reporting_client/exception_serializer.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class ExceptionSerializer < ActiveJob::Serializers::ObjectSerializer
+  def serialize?(argument)
+    argument.is_a?(StandardError)
+  end
+
+  def serialize(exception)
+    {
+      'class' => exception.class.name,
+      'message' => exception.message,
+      'detailed_message' => exception.respond_to?(:detailed_message) ? exception.detailed_message : nil,
+      'full_message' => exception.respond_to?(:full_message) ? exception.full_message : nil,
+      'backtrace_locations' => exception.respond_to?(:backtrace_locations) ? exception.backtrace_locations : nil,
+      'backtrace' => exception.backtrace,
+      'cause' => exception.cause,
+      'exception' => exception.respond_to?(:exception) ? exception.exception : nil,
+    }.compact_blank
+  end
+
+  def deserialize(hash)
+    error = hash['class'].constantize.new(hash['message'])
+    error.instance_variable_set(:@detailed_message, hash['detailed_message'])
+    error.instance_variable_set(:@full_message, hash['full_message'])
+    error.instance_variable_set(:@backtrace_locations, hash['backtrace_locations'])
+    error.instance_variable_set(:@backtrace, hash['backtrace'])
+    error.instance_variable_set(:@cause, hash['cause'])
+    error.instance_variable_set(:@exception, hash['exception'])
+    error
+  end
+end

--- a/lib/reporting_client/exception_serializer.rb
+++ b/lib/reporting_client/exception_serializer.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'json/add/exception'
-
 module ReportingClient
   class ExceptionSerializer < ActiveJob::Serializers::ObjectSerializer
     def serialize?(argument)
@@ -9,11 +7,17 @@ module ReportingClient
     end
 
     def serialize(exception)
-      exception.as_json
+      {
+        JSON.create_id => exception.class.name,
+        'm' => exception.message,
+        'b' => exception.backtrace
+      }
     end
 
     def deserialize(hash)
-      hash['json_class'].constantize.json_create(hash)
+      result = hash['json_class'].constantize.new(hash['m'])
+      result.set_backtrace hash['b']
+      result
     end
   end
 end

--- a/lib/reporting_client/exception_serializer.rb
+++ b/lib/reporting_client/exception_serializer.rb
@@ -1,31 +1,34 @@
 # frozen_string_literal: true
 
-class ExceptionSerializer < ActiveJob::Serializers::ObjectSerializer
-  def serialize?(argument)
-    argument.is_a?(StandardError)
-  end
+module ReportingClient
 
-  def serialize(exception)
-    {
-      'class' => exception.class.name,
-      'message' => exception.message,
-      'detailed_message' => exception.respond_to?(:detailed_message) ? exception.detailed_message : nil,
-      'full_message' => exception.respond_to?(:full_message) ? exception.full_message : nil,
-      'backtrace_locations' => exception.respond_to?(:backtrace_locations) ? exception.backtrace_locations : nil,
-      'backtrace' => exception.backtrace,
-      'cause' => exception.cause,
-      'exception' => exception.respond_to?(:exception) ? exception.exception : nil
-    }.compact_blank
-  end
+  class ExceptionSerializer < ActiveJob::Serializers::ObjectSerializer
+    def serialize?(argument)
+      argument.is_a?(StandardError)
+    end
 
-  def deserialize(hash)
-    error = hash['class'].constantize.new(hash['message'])
-    error.instance_variable_set(:@detailed_message, hash['detailed_message'])
-    error.instance_variable_set(:@full_message, hash['full_message'])
-    error.instance_variable_set(:@backtrace_locations, hash['backtrace_locations'])
-    error.instance_variable_set(:@backtrace, hash['backtrace'])
-    error.instance_variable_set(:@cause, hash['cause'])
-    error.instance_variable_set(:@exception, hash['exception'])
-    error
+    def serialize(exception)
+      {
+        'class' => exception.class.name,
+        'message' => exception.message,
+        'detailed_message' => exception.respond_to?(:detailed_message) ? exception.detailed_message : nil,
+        'full_message' => exception.respond_to?(:full_message) ? exception.full_message : nil,
+        'backtrace_locations' => exception.respond_to?(:backtrace_locations) ? exception.backtrace_locations : nil,
+        'backtrace' => exception.backtrace,
+        'cause' => exception.cause,
+        'exception' => exception.respond_to?(:exception) ? exception.exception : nil
+      }.compact_blank
+    end
+
+    def deserialize(hash)
+      error = hash['class'].constantize.new(hash['message'])
+      error.instance_variable_set(:@detailed_message, hash['detailed_message'])
+      error.instance_variable_set(:@full_message, hash['full_message'])
+      error.instance_variable_set(:@backtrace_locations, hash['backtrace_locations'])
+      error.instance_variable_set(:@backtrace, hash['backtrace'])
+      error.instance_variable_set(:@cause, hash['cause'])
+      error.instance_variable_set(:@exception, hash['exception'])
+      error
+    end
   end
 end

--- a/lib/reporting_client/exception_serializer.rb
+++ b/lib/reporting_client/exception_serializer.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
-require "json/add/exception"
+
+require 'json/add/exception'
 
 module ReportingClient
   class ExceptionSerializer < ActiveJob::Serializers::ObjectSerializer

--- a/lib/reporting_client/exception_serializer.rb
+++ b/lib/reporting_client/exception_serializer.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 module ReportingClient
-
   class ExceptionSerializer < ActiveJob::Serializers::ObjectSerializer
     def serialize?(argument)
       argument.is_a?(StandardError)

--- a/lib/reporting_client/exception_serializer.rb
+++ b/lib/reporting_client/exception_serializer.rb
@@ -14,7 +14,7 @@ class ExceptionSerializer < ActiveJob::Serializers::ObjectSerializer
       'backtrace_locations' => exception.respond_to?(:backtrace_locations) ? exception.backtrace_locations : nil,
       'backtrace' => exception.backtrace,
       'cause' => exception.cause,
-      'exception' => exception.respond_to?(:exception) ? exception.exception : nil,
+      'exception' => exception.respond_to?(:exception) ? exception.exception : nil
     }.compact_blank
   end
 

--- a/reporting_client.gemspec
+++ b/reporting_client.gemspec
@@ -32,7 +32,6 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'activejob'
   spec.add_runtime_dependency 'faraday', '>= 2.0'
-  spec.add_runtime_dependency 'json'
   spec.add_runtime_dependency 'request_store'
   spec.metadata['rubygems_mfa_required'] = 'true'
 end

--- a/reporting_client.gemspec
+++ b/reporting_client.gemspec
@@ -31,8 +31,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'webmock'
 
   spec.add_runtime_dependency 'activejob'
-  spec.add_runtime_dependency 'json'
   spec.add_runtime_dependency 'faraday', '>= 2.0'
+  spec.add_runtime_dependency 'json'
   spec.add_runtime_dependency 'request_store'
   spec.metadata['rubygems_mfa_required'] = 'true'
 end

--- a/reporting_client.gemspec
+++ b/reporting_client.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'webmock'
 
   spec.add_runtime_dependency 'activejob'
+  spec.add_runtime_dependency 'json'
   spec.add_runtime_dependency 'faraday', '>= 2.0'
   spec.add_runtime_dependency 'request_store'
   spec.metadata['rubygems_mfa_required'] = 'true'

--- a/spec/reporting_client/exception_serializer_spec.rb
+++ b/spec/reporting_client/exception_serializer_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 RSpec.describe ReportingClient::ExceptionSerializer do
   let(:error) { StandardError.new('test') }
   it 'serializes a StandardError' do
-    expect(ReportingClient::ExceptionSerializer.serialize(error)['message']).to eq('test')
+    expect(ReportingClient::ExceptionSerializer.serialize(error)['m']).to eq('test')
   end
 
   it 'deserializes a StandardError' do

--- a/spec/reporting_client/exception_serializer_spec.rb
+++ b/spec/reporting_client/exception_serializer_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require_relative '../../lib/reporting_client/exception_serializer'
+
+RSpec.describe ExceptionSerializer do
+  let(:error) { StandardError.new('test') }
+  it 'serializes a StandardError' do
+    expect(ExceptionSerializer.serialize(error)['message']).to eq('test')
+  end
+
+  it 'deserializes a StandardError' do
+    serialized_error = ExceptionSerializer.serialize(error)
+    expect(ExceptionSerializer.deserialize(serialized_error).message).to eq('test')
+  end
+end

--- a/spec/reporting_client/exception_serializer_spec.rb
+++ b/spec/reporting_client/exception_serializer_spec.rb
@@ -12,4 +12,8 @@ RSpec.describe ExceptionSerializer do
     serialized_error = ExceptionSerializer.serialize(error)
     expect(ExceptionSerializer.deserialize(serialized_error).message).to eq('test')
   end
+
+  it 'validates that the argument is a StandardError' do
+    expect(ExceptionSerializer.serialize?(error)).to eq(true)
+  end
 end

--- a/spec/reporting_client/exception_serializer_spec.rb
+++ b/spec/reporting_client/exception_serializer_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require_relative '../../lib/reporting_client/exception_serializer'
 
 RSpec.describe ExceptionSerializer do
   let(:error) { StandardError.new('test') }

--- a/spec/reporting_client/exception_serializer_spec.rb
+++ b/spec/reporting_client/exception_serializer_spec.rb
@@ -2,18 +2,18 @@
 
 require 'spec_helper'
 
-RSpec.describe ExceptionSerializer do
+RSpec.describe ReportingClient::ExceptionSerializer do
   let(:error) { StandardError.new('test') }
   it 'serializes a StandardError' do
-    expect(ExceptionSerializer.serialize(error)['message']).to eq('test')
+    expect(ReportingClient::ExceptionSerializer.serialize(error)['message']).to eq('test')
   end
 
   it 'deserializes a StandardError' do
-    serialized_error = ExceptionSerializer.serialize(error)
-    expect(ExceptionSerializer.deserialize(serialized_error).message).to eq('test')
+    serialized_error = ReportingClient::ExceptionSerializer.serialize(error)
+    expect(ReportingClient::ExceptionSerializer.deserialize(serialized_error).message).to eq('test')
   end
 
   it 'validates that the argument is a StandardError' do
-    expect(ExceptionSerializer.serialize?(error)).to eq(true)
+    expect(ReportingClient::ExceptionSerializer.serialize?(error)).to eq(true)
   end
 end


### PR DESCRIPTION
We need to be able to serialize exceptions so that you can use Heap async and pass exceptions to it. For example, if you call Heap with an exception with async on, then it will fail. To use this, you will have to add somewhere in your rails app initialization `Rails.application.config.active_job.custom_serializers << ExceptionSerializer`