### PR TITLE
registering custom event names from CSV

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 
 references:
   default_docker_ruby_executor: &default_docker_ruby_executor
-    image: circleci/ruby:2.7.1-node-browsers
+    image: cimg/ruby:3.3.0
     environment:
       BUNDLE_PATH: vendor/bundle
       RAILS_ENV: test

--- a/lib/reporting_client.rb
+++ b/lib/reporting_client.rb
@@ -25,4 +25,8 @@ module ReportingClient
   def self.configure
     yield configuration
   end
+
+  def self.root
+    Pathname.new(File.expand_path('..', __dir__))
+  end
 end

--- a/lib/reporting_client/configuration.rb
+++ b/lib/reporting_client/configuration.rb
@@ -3,7 +3,7 @@
 module ReportingClient
   class Configuration
     attr_accessor :environment, :heap_app_id, :instrumentable_name, :timeout, :request_logger,
-                  :prefix_new_relic_names, :raises_on_unsupported_event
+                  :prefix_new_relic_names, :raises_on_unsupported_event, :registry_csv_path
 
     def initialize
       @environment = nil
@@ -13,6 +13,7 @@ module ReportingClient
       @timeout = nil
       @prefix_new_relic_names = false
       @raises_on_unsupported_event = false
+      @registry_csv_path = nil
     end
   end
 end

--- a/lib/reporting_client/events.rb
+++ b/lib/reporting_client/events.rb
@@ -2,6 +2,7 @@
 
 require 'active_support'
 require 'rubygems'
+require 'csv'
 
 require_relative 'event'
 
@@ -21,6 +22,15 @@ module ReportingClient
 
         events << event_name
         subscribe(instrumentable_name(event_name))
+      end
+
+      def register_events_from_registry_csv
+        raise ReportingClient::Exceptions::MissingRegistryCsvPath if ReportingClient.configuration.registry_csv_path.blank?
+
+        documented_custom_events = CSV.read(ReportingClient.configuration.registry_csv_path, headers: true)
+        documented_custom_events.each do |event|
+          register(event['event_name'])
+        end
       end
 
       def subscribe(event_name)

--- a/lib/reporting_client/exceptions.rb
+++ b/lib/reporting_client/exceptions.rb
@@ -2,6 +2,8 @@
 
 module ReportingClient
   module Exceptions
+    MissingRegistryCsvPath = StandardError.new
+
     class UnregisteredEventError < StandardError
       attr_reader :event_name
 
@@ -10,7 +12,7 @@ module ReportingClient
         must be registered prior to attempting to instrument them so that they are successfully
         dispatched to the appropriate services.
 
-        In order to register an event type, call `ReportingClient::Events.register(your_event_name)`.
+        In order to register an event type, add your event to the csv configured under `registry_csv_path`.
         This action is idemptotent, and it can be run multiple times for safety. You can disable
         this error by configuring `raises_on_unsupported_event` to be false.
       MESSAGE

--- a/spec/support/custom_events.csv
+++ b/spec/support/custom_events.csv
@@ -1,0 +1,3 @@
+funnel,event_name,description
+Stuff Funnel,DoStuff,This funnel does the stuff
+Funnel Cake,FindSynergies,I like funnel cake


### PR DESCRIPTION
* added `ReportingClient::Events.register_events_from_registry_csv` to register events w/ ActiveSupport::Notifications from a CSV on app boot.
* raising `MissingRegistryCsvPath ` exception if register_events_from_registry_csv is called without ReportingClient.configuration.registry_csv_path being configured
* removing specific exception from negative assertion in events_spec.rb to appease rspec best practices
* adding ReportingClient.root to easily find the root dir of the project for use in spec