### PR TITLE
MAR-646 | BUG | reportingclient make timestamp a value to heap

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 
 references:
   default_docker_ruby_executor: &default_docker_ruby_executor
-    image: circleci/ruby:2.7.1-node-browsers
+    image: cimg/ruby:3.3.0
     environment:
       BUNDLE_PATH: vendor/bundle
       RAILS_ENV: test

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 3.2
   NewCops: enable
   Exclude:
     - 'bin/**/*'
@@ -42,4 +42,7 @@ Style/RegexpLiteral:
   EnforcedStyle: percent_r
 
 Style/GuardClause:
+  Enabled: false
+
+Style/HashSyntax:
   Enabled: false

--- a/lib/reporting_client/heap.rb
+++ b/lib/reporting_client/heap.rb
@@ -7,7 +7,7 @@ require_relative './heap_job'
 
 module ReportingClient
   class Heap
-    attr_accessor :event_name, :properties, :identity
+    attr_accessor :event_name, :properties, :identity, :timestamp
 
     HEAP_EVENT_TRACKING_URL = 'https://heapanalytics.com/api/track'
 
@@ -15,15 +15,16 @@ module ReportingClient
       new(**args).call
     end
 
-    def initialize(event_name:, identity:, properties:)
+    def initialize(event_name:, identity:, properties:, timestamp: Time.now.iso8601)
       @event_name = event_name
       @identity = identity
       @properties = properties
+      @timestamp = timestamp
     end
 
     def call
       if config.heap_async
-        HeapJob.perform_later(event_name, identity, properties)
+        HeapJob.perform_later(event_name, identity, properties, timestamp)
       else
         track
       end
@@ -56,7 +57,7 @@ module ReportingClient
       { app_id: config.heap_app_id,
         identity: identity,
         event: event_name,
-        timestamp: Time.now.iso8601,
+        timestamp: timestamp || Time.now.iso8601,
         properties: properties.transform_keys(&:to_sym) }
     end
 

--- a/lib/reporting_client/heap_job.rb
+++ b/lib/reporting_client/heap_job.rb
@@ -5,7 +5,7 @@ require_relative './heap'
 
 module ReportingClient
   class HeapJob < ActiveJob::Base
-    def perform(event_name, identity, properties, timestamp=Time.now.iso8601)
+    def perform(event_name, identity, properties, timestamp = Time.now.iso8601)
       Heap.new(event_name: event_name, identity: identity, properties: properties, timestamp: timestamp).track
     end
   end

--- a/lib/reporting_client/heap_job.rb
+++ b/lib/reporting_client/heap_job.rb
@@ -5,8 +5,8 @@ require_relative './heap'
 
 module ReportingClient
   class HeapJob < ActiveJob::Base
-    def perform(event_name, identity, properties)
-      Heap.new(event_name: event_name, identity: identity, properties: properties).track
+    def perform(event_name, identity, properties, timestamp=Time.now.iso8601)
+      Heap.new(event_name:, identity:, properties:, timestamp:).track
     end
   end
 end

--- a/lib/reporting_client/heap_job.rb
+++ b/lib/reporting_client/heap_job.rb
@@ -6,7 +6,7 @@ require_relative './heap'
 module ReportingClient
   class HeapJob < ActiveJob::Base
     def perform(event_name, identity, properties, timestamp=Time.now.iso8601)
-      Heap.new(event_name:, identity:, properties:, timestamp:).track
+      Heap.new(event_name: event_name, identity: identity, properties: properties, timestamp: timestamp).track
     end
   end
 end

--- a/reporting_client.gemspec
+++ b/reporting_client.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
 
   spec.summary       = 'Consolidation of reporting API calls into a singular gem.'
   spec.description   = 'Consolidates any calls using reporting API into one place.'
-  spec.required_ruby_version = Gem::Requirement.new('>= 2.5.0')
+  spec.required_ruby_version = Gem::Requirement.new('>= 3.2.0')
 
   spec.files = Dir.chdir(File.expand_path(__dir__)) do
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }

--- a/spec/reporting_client/heap_job_spec.rb
+++ b/spec/reporting_client/heap_job_spec.rb
@@ -3,6 +3,6 @@
 RSpec.describe ReportingClient::HeapJob do
   it 'calls Heap#track' do
     expect_any_instance_of(ReportingClient::Heap).to receive(:track)
-    described_class.perform_now('event_name', 'identity', 'properties')
+    described_class.perform_now('event_name', 'identity', 'properties', 'timestamp')
   end
 end

--- a/spec/reporting_client/heap_spec.rb
+++ b/spec/reporting_client/heap_spec.rb
@@ -51,8 +51,10 @@ RSpec.describe ReportingClient::Heap do
   context 'with heap async set to true' do
     it 'enqueues a heap job' do
       allow(config).to receive(:heap_async).and_return(true)
+      timestamp = Time.now
+      expect(Time).to receive(:now).and_return(timestamp)
 
-      expect(ReportingClient::HeapJob).to receive(:perform_later).with(event_name, program_name, properties)
+      expect(ReportingClient::HeapJob).to receive(:perform_later).with(event_name, program_name, properties, timestamp.iso8601)
       expect(Faraday).not_to receive(:new)
       subject
     end


### PR DESCRIPTION
Add default timestamp to heap job. We want the timestamp to be when the job is enqueued, not when the job runs, this way if the queues get backed up, the timestamp will always be when the event happened.

https://trello.com/c/PmYDg5Ux/646-reportingclient-make-timestamp-a-value-to-heap