### PR TITLE
Rails 7.2 Support

### DIFF
--- a/lib/reporting_client/current.rb
+++ b/lib/reporting_client/current.rb
@@ -32,6 +32,8 @@ module ReportingClient
       end
     end
 
-    public :assign_attributes
+    def assign_attributes(new_attributes)
+      new_attributes.each { |key, value| public_send("#{key}=", value) }
+    end
   end
 end

--- a/reporting_client.gemspec
+++ b/reporting_client.gemspec
@@ -30,8 +30,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'webmock'
 
-  spec.add_runtime_dependency 'activesupport', '~> 7.2'
   spec.add_runtime_dependency 'activejob'
+  spec.add_runtime_dependency 'activesupport', '~> 7.2'
   spec.add_runtime_dependency 'faraday', '>= 2.0'
   spec.add_runtime_dependency 'request_store'
   spec.metadata['rubygems_mfa_required'] = 'true'

--- a/reporting_client.gemspec
+++ b/reporting_client.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'webmock'
 
-  spec.add_runtime_dependency 'activesupport', '~> 7.1.0'
+  spec.add_runtime_dependency 'activesupport', '~> 7.2'
   spec.add_runtime_dependency 'activejob'
   spec.add_runtime_dependency 'faraday', '>= 2.0'
   spec.add_runtime_dependency 'request_store'

--- a/reporting_client.gemspec
+++ b/reporting_client.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'webmock'
 
+  spec.add_runtime_dependency 'activesupport', '~> 7.1.0'
   spec.add_runtime_dependency 'activejob'
   spec.add_runtime_dependency 'faraday', '>= 2.0'
   spec.add_runtime_dependency 'request_store'


### PR DESCRIPTION
`ActiveSupport::CurrentAttributes` does not support the method `assign_attributes` anymore:

https://api.rubyonrails.org/classes/ActiveSupport/CurrentAttributes.html

The method was removed:

https://github.com/rails/rails/blame/2d6b02bad6b02bf1d26c26461406bda710181244/activesupport/lib/active_support/current_attributes.rb

What the core issue is that we were using a `private` method within `activesupport`. 